### PR TITLE
remove polling loop, wait for events

### DIFF
--- a/util/hookserve/main.go
+++ b/util/hookserve/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/phayes/hookserve/hookserve"
 	"os"
 	"os/exec"
-	"time"
 )
 
 func main() {
@@ -40,21 +39,16 @@ func main() {
 		server.Secret = c.String("secret")
 		server.GoListenAndServe()
 
-		for {
-			select {
-			case commit := <-server.Events:
-				if args := c.Args(); len(args) != 0 {
-					root := args[0]
-					rest := append(args[1:], commit.Owner, commit.Repo, commit.Branch, commit.Commit)
-					cmd := exec.Command(root, rest...)
-					cmd.Stdout = os.Stdout
-					cmd.Stderr = os.Stderr
-					cmd.Run()
-				} else {
-					fmt.Println(commit.Owner + " " + commit.Repo + " " + commit.Branch + " " + commit.Commit)
-				}
-			default:
-				time.Sleep(100)
+		for commit := range server.Events {
+			if args := c.Args(); len(args) != 0 {
+				root := args[0]
+				rest := append(args[1:], commit.Owner, commit.Repo, commit.Branch, commit.Commit)
+				cmd := exec.Command(root, rest...)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				cmd.Run()
+			} else {
+				fmt.Println(commit.Owner + " " + commit.Repo + " " + commit.Branch + " " + commit.Commit)
 			}
 		}
 	}


### PR DESCRIPTION
The main loop was looking for new events or time-out of a timer -
which was set to 100 nanoseconds (!). This created a lot of CPU
utilization waiting for basically nothing. Replaced this with
a loop over the range of the event channel.
