### PR TITLE
Add option --tags: execute command also when a tag is pushed.

### DIFF
--- a/util/hookserve/main.go
+++ b/util/hookserve/main.go
@@ -32,12 +32,17 @@ func main() {
 			Value: "",
 			Usage: "Secret for HMAC verification. If not provided no HMAC verification will be done and all valid requests will be processed",
 		},
+		cli.BoolFlag{
+			Name:  "tags, t",
+			Usage: "Also execute the command when a tag is pushed",
+		},
 	}
 
 	app.Action = func(c *cli.Context) {
 		server := hookserve.NewServer()
 		server.Port = c.Int("port")
 		server.Secret = c.String("secret")
+		server.IgnoreTags = !c.Bool("tags")
 		server.GoListenAndServe()
 
 		for {


### PR DESCRIPTION
I use tags for marking commits that should be deployed to our live environment. This PR adds the tags flag:

```
--tags, -t           Also execute the command when a tag is pushed
```

If present the command will be executed if a tag is pushed.
