### PR TITLE
Adds IssueID to Event struct

### DIFF
--- a/hookserve/hookserve.go
+++ b/hookserve/hookserve.go
@@ -24,6 +24,7 @@ type Event struct {
 	BaseOwner  string // For Pull Requests, contains the base owner
 	BaseRepo   string // For Pull Requests, contains the base repo
 	BaseBranch string // For Pull Requests, contains the base branch
+	IssueID    int    // For Pull Requests, contains the related issue ID
 }
 
 // Create a new event from a string, the string format being the same as the one produced by event.String()
@@ -263,6 +264,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		IssueID, err := request.Get("pull_request").Get("number").Number()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		event.IssueID = int(IssueID)
 	} else {
 		http.Error(w, "Unknown Event Type "+eventType, http.StatusInternalServerError)
 		return


### PR DESCRIPTION
The github api requires the Issue ID to be specified for many actions (e.g, commenting on PRs or changing status) this PR adds the related Issue ID for a pull request to the Event struct.
