### PR TITLE
Fixed high CPU usage example code.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -10,7 +10,7 @@ HookServe is a small golang utility for receiving github webhooks. It's easy to 
         case event := <-server.Events:
             fmt.Println(event.Owner + " " + event.Repo + " " + event.Branch + " " + event.Commit)
         default:
-            time.Sleep(100)
+            time.Sleep(time.Millisecond * 100)
         }
     }
 

--- a/hookserve/hookserve.go
+++ b/hookserve/hookserve.go
@@ -150,7 +150,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "400 Bad Request - Missing X-GitHub-Event Header", http.StatusBadRequest)
 		return
 	}
-	if eventType != "push" && eventType != "pull_request" {
+	if eventType != "push" && eventType != "pull_request" && eventType != "ping" {
 		http.Error(w, "400 Bad Request - Unknown Event Type "+eventType, http.StatusBadRequest)
 		return
 	}
@@ -263,6 +263,28 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+	} else if eventType == "ping" {
+		event.Type = eventType
+
+		event.Branch, err = request.Get("repository").Get("default_branch").String()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+
+		event.Repo, err = request.Get("repository").Get("name").String()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		event.Owner, err = request.Get("repository").Get("owner").Get("login").String()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
 	} else {
 		http.Error(w, "Unknown Event Type "+eventType, http.StatusInternalServerError)
 		return
@@ -275,3 +297,4 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	w.Write([]byte(event.String()))
 }
+


### PR DESCRIPTION
The current doc code snippet sleeps for only 100ns, this leads to a sample program that is basically polling the channel.
I increased it to 100ms, which I'd argue is a good tradeoff between resource consumption and real-time hooks. 